### PR TITLE
Allow DATABASE_URL to be used for any enviroment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,7 @@ default: &default
   host: localhost
   port: 5432
   pool: <%= ENV['DB_POOL'] || ENV['MAX_THREADS'] || 5 %>
+  url: <%= ENV['DATABASE_URL'] %>
   timeout: 5000
 
 development:


### PR DESCRIPTION
The DATABASE_URL setting will be used if it is present, otherwise the existing
defaults are used for development and test.
