### PR TITLE
Use QuotaGuard to avoid geocoder rate limits

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,5 +1,6 @@
 Geocoder.configure(
   lookup: :google,
+  http_proxy: ENV['QUOTAGUARD_URL'],
   always_raise: [
     Geocoder::OverQueryLimitError,
     Geocoder::RequestDenied,


### PR DESCRIPTION
Nancy Au from YPI was running into geocoder rate limit issues when trying to add some locations to Ohana. This PR attempts to use QuotaGuard as an HTTP proxy to avoid rate limit issues for Google's free geocoding tier due to shared outbound IP addresses for our Heroku instance.